### PR TITLE
Add support and tests for generic array paths

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -12,6 +12,9 @@ const changed_customer = {
     nested: '2Bye',
     nested2: '2Hello2',
   },
+  nested_array: [{
+    nested_value: 'New value',
+  }],
   contacts: [{
     name: 'Test contact 0 name',
     phones: ['Test contact 0 phone 0', 'Test contact 0 phone 1'],
@@ -30,6 +33,7 @@ const diffs = [
   {path: '/contacts/1/emails', old_value: ['contact 1 old email 0', 'Test contact 1 email 1']},
   {path: '/nested/nested2', old_value: 'Hello2'},
   {path: '/nested2', old_value: { nested: '2Hello', nested2: '2Hello2' }},
+  {path: '/nested_array/0/nested_value', old_value: 'Old value'},
 ]
 
 describe('pathHasChanged', () => {
@@ -66,5 +70,27 @@ describe('pathHasChanged', () => {
   test('Nested.nested2 path has not changed', () => {
     expect(pathHasChanged(changed_customer, diffs, '/nested2/nested2')).toBe(false);
   });
-
+  describe('Allow `-` to check every array subpath at once', () => {
+    test('Some contact name has changed', () => {
+      expect(pathHasChanged(changed_customer, diffs, '/contacts/-/name', {handle_array_paths: true})).toBe(true);
+    });
+    test('Some phone has changed', () => {
+      expect(pathHasChanged(changed_customer, diffs, '/contacts/-/phones', {handle_array_paths: true})).toBe(true);
+    });
+    test('Some email has changed', () => {
+      expect(pathHasChanged(changed_customer, diffs, '/contacts/-/emails', {handle_array_paths: true})).toBe(true);
+    });
+    test('Some email has changed generic', () => {
+      expect(pathHasChanged(changed_customer, diffs, '/contacts/-/emails/-', {handle_array_paths: true})).toBe(true);
+    });
+    test('Some first email has changed', () => {
+      expect(pathHasChanged(changed_customer, diffs, '/contacts/-/emails/0', {handle_array_paths: true})).toBe(true);
+    });
+    test('Some nested array value has changed', () => {
+      expect(pathHasChanged(changed_customer, diffs, '/nested_array', {handle_array_paths: true})).toBe(true);
+    });
+    test('Some nested array value generic has changed', () => {
+      expect(pathHasChanged(changed_customer, diffs, '/nested_array/-', {handle_array_paths: true})).toBe(true);
+    });
+  })
 });


### PR DESCRIPTION
Generic array paths `-` are a way to refer to all elements of an array path at the same time.

This allows us to check if any of the values of the array has changes without having to check for every one of them independently